### PR TITLE
Sanitize existing instance variables in Wallet the singleton

### DIFF
--- a/Wallet.cpp
+++ b/Wallet.cpp
@@ -97,6 +97,11 @@ bool Wallet::generateWallet() {
 }
 
 bool Wallet::initWallet() {
+    this->privateKeys = std::vector< std::vector<unsigned char> >();
+    this->publicKeys = std::vector< std::vector<unsigned char> >();
+    this->addressesScript = std::vector< std::vector<unsigned char> >();
+    this->addressesLink = std::vector< std::vector<unsigned char> >();
+    
     return this->generateWallet();
 }
 


### PR DESCRIPTION
When calling initWallet the existing instances variables such as privateKeys, publicKeys ... are not cleared.
This caused me to have some problems when porting the code to the iOS wallet.

I believe this should be the expected behavior from the initWallet() function